### PR TITLE
fix/empty-files-input-stream-checksum-failure

### DIFF
--- a/src/main/java/io/kestra/storage/s3/S3Storage.java
+++ b/src/main/java/io/kestra/storage/s3/S3Storage.java
@@ -64,13 +64,14 @@ public class S3Storage implements StorageInterface {
         return get(path);
     }
 
-    private ResponseInputStream<GetObjectResponse> get(String path) throws IOException {
+    private InputStream get(String path) throws IOException {
         try {
             GetObjectRequest request = GetObjectRequest.builder()
                 .bucket(s3Config.getBucket())
                 .key(path)
                 .build();
-            return s3Client.getObject(request);
+            ResponseInputStream<GetObjectResponse> inputStream = s3Client.getObject(request);
+            return inputStream.response().contentLength() == 0 ? InputStream.nullInputStream() : inputStream;
         } catch (NoSuchKeyException exception) {
             throw new FileNotFoundException();
         } catch (AwsServiceException exception) {

--- a/src/test/java/io/kestra/storage/s3/S3StorageTest.java
+++ b/src/test/java/io/kestra/storage/s3/S3StorageTest.java
@@ -2,14 +2,21 @@ package io.kestra.storage.s3;
 
 import io.kestra.core.storage.StorageTestSuite;
 import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.core.ResponseInputStream;
 
-import java.io.IOException;
+import java.io.*;
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 class S3StorageTest extends StorageTestSuite {
     @Inject
@@ -38,5 +45,20 @@ class S3StorageTest extends StorageTestSuite {
             ((S3Storage) storageInterface).createBucket();
         } catch (IOException ignored) {
         }
+    }
+
+    /**
+     * This test ensures that in case of an empty file, we return a raw empty input stream and not a ResponseInputStream.
+     * This is needed as the ResponseInputStream in case of an empty file still returns some data which prevents the checksum to work and leads to a stream reading failure.
+     */
+    @Test
+    void getEmptyFile() throws IOException {
+        String prefix = IdUtils.create();
+        URI uri = URI.create("/" + prefix + "/empty.txt");
+        storageInterface.put(null, uri, new ByteArrayInputStream(new byte[0]));
+
+        InputStream inputStream = storageInterface.get(null, uri);
+        assertThat(inputStream, not(instanceOf(ResponseInputStream.class)));
+        assertThat(new BufferedReader(new InputStreamReader(inputStream)).lines().count(), is(0L));
     }
 }


### PR DESCRIPTION
Empty files couldn't be opened due to AWS SDK failing on checksum because it is returning data in its InputStream