### PR TITLE
fix/empty-and-absent-dir-detection

### DIFF
--- a/src/main/java/io/kestra/storage/s3/S3Storage.java
+++ b/src/main/java/io/kestra/storage/s3/S3Storage.java
@@ -98,10 +98,9 @@ public class S3Storage implements StorageInterface {
                 })
                 .map(throwFunction(this::getFileAttributes))
                 .toList();
-            if (list.isEmpty()) {
-                // s3 does not handle directory deleting with a prefix that does not exist will just delete nothing
-                // Deleting an "empty directory" will at least return the directory name
-                throw new FileNotFoundException(uri + " (Not Found)");
+            if(list.isEmpty()) {
+                // this will throw FileNotFound if there is no directory
+                this.getAttributes(tenantId, uri);
             }
             return list;
         } catch (NoSuchKeyException exception) {


### PR DESCRIPTION
Empty directories were throwing exceptions and the old code makes no sense to me (I think it's a mistake as it talks about deletion while we're in list method).
Moreover, I had to still maintain a non-existent directory detection for tests to pass