### PR TITLE
fix: handle nullable tenantId for cluster-wide operation

### DIFF
--- a/src/main/java/io/kestra/storage/s3/S3Storage.java
+++ b/src/main/java/io/kestra/storage/s3/S3Storage.java
@@ -461,9 +461,10 @@ public class S3Storage implements S3Config, StorageInterface {
     }
 
     private static URI createUri(String tenantId, String key) {
-        return URI.create("kestra://%s".formatted(key).replace(tenantId, ""));
+        return URI.create(tenantId == null ? "kestra://%s".formatted(key) : "kestra://%s".formatted(key).replace(tenantId, ""));
     }
 
+    @Override
     public void close() {
         if (this.s3Client != null) {
             try {


### PR DESCRIPTION
(kestra-io/kestra-ee#4488)

Related-to: kestra-io/kestra-ee#4488
